### PR TITLE
Removed duplicate core import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@ introspection of method/constructor parameter names, without having to add expli
 
     <!-- Configuration properties for the OSGi maven-bundle-plugin -->
     <osgi.import>com.fasterxml.jackson.core
-,com.fasterxml.jackson.core
 ,com.fasterxml.jackson.core.json
 ,com.fasterxml.jackson.core.util
 ,com.fasterxml.jackson.databind


### PR DESCRIPTION
Knopflerfish that I am using for a project doesn't like duplicate imports... And I see no reason for it to be there.