### PR TITLE
Failing tests for wrappers

### DIFF
--- a/src/test/java/com/fasterxml/jackson/module/paramnames/TestWrappers.java
+++ b/src/test/java/com/fasterxml/jackson/module/paramnames/TestWrappers.java
@@ -1,0 +1,64 @@
+package com.fasterxml.jackson.module.paramnames;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertNotNull;
+
+public class TestWrappers {
+
+    public static class IntWrapper
+    {
+        private final int value;
+
+        @JsonCreator
+        public IntWrapper(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
+
+    public static class GenericWrapper<T>
+    {
+        private final T value;
+
+        @JsonCreator
+        public GenericWrapper(T value) {
+            this.value = value;
+        }
+
+        public T getValue() {
+            return value;
+        }
+    }
+
+    @Test
+    @Ignore
+    public void testWrapper() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        mapper.registerModule(new ParameterNamesModule());
+
+        IntWrapper result = mapper.readValue
+                ("{\"value\":13}", IntWrapper.class);
+        assertNotNull(result);
+    }
+
+    @Test
+    @Ignore
+    public void testGenericWrapper() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        mapper.registerModule(new ParameterNamesModule());
+
+        GenericWrapper<Integer> result = mapper.readValue
+            ("{\"value\":13}", new TypeReference<GenericWrapper<Integer>>() { });
+        assertNotNull(result);
+    }
+}


### PR DESCRIPTION
This commit adds two tests for simple bean objects that wrap values; the normal Jackson use case requires the use of `@JsonProperty` annotations in the constructor and works fine, but fails when using the parameter names module. I suspect the start of the issue is here:

[BasicDeserializerFactory.java#L443](https://github.com/FasterXML/jackson-databind/blob/6fc1974509e16eefb84ac00da03d8e2839b01f4a/src/main/java/com/fasterxml/jackson/databind/deser/BasicDeserializerFactory.java#L443)

Without explicit names, the single argument use case kicks out of the "constructorProperty" path and relies on the "delegatingConstructor" path, which fails because they expect simple integers rather than JSON objects.

Because of the changes to creators in 2.5, this also ends up being a blocking issue for the Scala module's upgrade to 2.5.
