### PR TITLE
Remove override of json creator mode

### DIFF
--- a/src/main/java/com/fasterxml/jackson/module/paramnames/ParameterNamesAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/module/paramnames/ParameterNamesAnnotationIntrospector.java
@@ -36,6 +36,11 @@ class ParameterNamesAnnotationIntrospector extends NopAnnotationIntrospector
     @Override
     public JsonCreator.Mode findCreatorBinding(Annotated a) {
 
+        JsonCreator ann = a.getAnnotation(JsonCreator.class);
+        if (ann != null) {
+            return ann.mode();
+        }
+
         return creatorBinding;
     }
 

--- a/src/test/java/com/fasterxml/jackson/module/paramnames/DelegatingCreatorTest.java
+++ b/src/test/java/com/fasterxml/jackson/module/paramnames/DelegatingCreatorTest.java
@@ -1,0 +1,45 @@
+package com.fasterxml.jackson.module.paramnames;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+public class DelegatingCreatorTest {
+
+	@Test
+	public void shouldNotOverrideJsonCreatorAnnotationWithSpecifiedMode() throws IOException {
+
+		// given
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new ParameterNamesModule(JsonCreator.Mode.PROPERTIES));
+
+		// when
+		ClassWithDelegatingCreator actual = objectMapper.readValue("{\"value\":\"aValue\"}", ClassWithDelegatingCreator.class);
+
+		// then
+		Map<String, String> props = new HashMap<>();
+		props.put("value", "aValue");
+		ClassWithDelegatingCreator expected = new ClassWithDelegatingCreator(props);
+		then(actual).isEqualToComparingFieldByField(expected);
+	}
+
+	static class ClassWithDelegatingCreator {
+
+		private final String value;
+
+		@JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+		ClassWithDelegatingCreator(Map<String, String> props) {
+			this.value = props.get("value");
+		}
+
+		String getValue() {
+			return value;
+		}
+	}
+}


### PR DESCRIPTION
@cowtowncoder , I have thought about your comment in [issue-21](https://github.com/FasterXML/jackson-module-parameter-names/issues/21) and you are right, JacksonAnnotationIntrospector should not override JsonCreator annotation with mode if a user specifies one on his class.
This PR fixes that issue.