### PR TITLE
fixed wrong version being imported in ParameterNamesModule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@ introspection of method/constructor parameter names, without having to add expli
     <!-- Generate PackageVersion.java into this directory. -->
     <packageVersion.dir>com/fasterxml/jackson/module/paramnames</packageVersion.dir>
     <packageVersion.package>${project.groupId}.paramnames</packageVersion.package>
-    <assertj-core.version>2.0.0</assertj-core.version>
+    <assertj-core.version>3.2.0</assertj-core.version>
 
     <!-- Configuration properties for the OSGi maven-bundle-plugin -->
     <osgi.import>com.fasterxml.jackson.core

--- a/src/main/java/com/fasterxml/jackson/module/paramnames/ParameterNamesModule.java
+++ b/src/main/java/com/fasterxml/jackson/module/paramnames/ParameterNamesModule.java
@@ -1,7 +1,6 @@
 package com.fasterxml.jackson.module.paramnames;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.core.json.PackageVersion;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 public class ParameterNamesModule extends SimpleModule


### PR DESCRIPTION
While doing tests for https://github.com/FasterXML/jackson-databind/pull/985 I've detected a bug in module version import. (test - https://github.com/lpandzic/jackson-databind/blob/fix-issue-%23982/src/test/java/com/fasterxml/jackson/databind/DefaultModuleLoaderTest.java).