### PR TITLE
Add hasCreatorAnnotation for old (2.6) Jackson vers

### DIFF
--- a/src/main/java/com/fasterxml/jackson/module/paramnames/ParameterNamesAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/module/paramnames/ParameterNamesAnnotationIntrospector.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.introspect.*;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.MalformedParametersException;
 import java.lang.reflect.Parameter;
 
@@ -45,6 +46,18 @@ class ParameterNamesAnnotationIntrospector extends NopAnnotationIntrospector {
         }
 
         return creatorBinding;
+    }
+
+    @Deprecated // since 2.9
+    @Override
+    public boolean hasCreatorAnnotation(Annotated a) {
+        if (a instanceof AnnotatedConstructor) {
+            Constructor<?>[] constructors = ((AnnotatedConstructor) a).getDeclaringClass().getConstructors();
+            if (constructors.length == 1 && constructors[0].equals(a.getAnnotated())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private String findParameterName(AnnotatedParameter annotatedParameter) {


### PR DESCRIPTION
Single argument constructors in old versions of Jackson have special
case handling which prevent implicit parameter names from being used.

This change adds a hasCreatorAnnotation implementation which will mark a
constructor as a creator iff it's the only constructor.